### PR TITLE
Switch to AOT and Source-Generated Regex

### DIFF
--- a/hyprwatch.csproj
+++ b/hyprwatch.csproj
@@ -5,8 +5,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/GetWindows.cs
+++ b/src/GetWindows.cs
@@ -4,7 +4,7 @@ namespace hyprwatch.Window
   using System.Diagnostics;
   using System.Text.RegularExpressions;
 
-  public class GetWindows
+  public partial class GetWindows
   {
     public static string ActiveWindow()
     {
@@ -28,7 +28,7 @@ namespace hyprwatch.Window
         string output = process.StandardOutput.ReadToEnd();
         process.WaitForExit();
 
-        var classMatch = Regex.Match(output, @"class:(.+)");
+        var classMatch = ClassRegex().Match(output);
 
         if(classMatch.Success)
         {
@@ -47,5 +47,8 @@ namespace hyprwatch.Window
 
       return activeWindow ?? string.Empty;
     }
-  }
+
+        [GeneratedRegex(@"class:(.+)")]
+        private static partial Regex ClassRegex();
+    }
 }


### PR DESCRIPTION
The code doesn't use reflection or dynamic code-gen so it should be able to be published w aot just fine for smaller binary size and faster startup. Also switched the regex to use source gen since that's preferred.